### PR TITLE
Revert "build(deps): bump sigstore/cosign-installer from 3.10.0 to 4.0.0"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,7 +113,7 @@ jobs:
           password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
 
       - name: Sign container image


### PR DESCRIPTION
Reverts tuque-os/workstation#29

See if this caused the issue with trying to upgade

> error: Upgrading: Preparing import: Fetching manifest: failed to invoke method OpenImage: A signature was required, but no signature exists